### PR TITLE
[GHA] Expand Slack notifications to include cancelled, failed, and successful states.

### DIFF
--- a/.github/workflows/auto-simple-suite.yaml
+++ b/.github/workflows/auto-simple-suite.yaml
@@ -36,6 +36,11 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  post-slack-notification:
+    runs-on: ubuntu-latest
+    needs: run-simple-suite 
+    if: success()
+    steps:
       - name: Post to Slack
         env: 
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/auto-simple-suite.yaml
+++ b/.github/workflows/auto-simple-suite.yaml
@@ -36,7 +36,31 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
-  post-slack-notification:
+  post-slack-notification-started:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        env: 
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{"text":"Simple suite pipeline started"}' \
+          $SLACK_WEBHOOK_URL
+
+  post-slack-notification-failure:
+    runs-on: ubuntu-latest
+    needs: run-simple-suite 
+    if: failure()
+    steps:
+      - name: Post to Slack
+        env: 
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{"text":"Simple suite pipeline failed"}' \
+          $SLACK_WEBHOOK_URL
+
+  post-slack-notification-success:
     runs-on: ubuntu-latest
     needs: run-simple-suite 
     if: success()

--- a/.github/workflows/auto-simple-suite.yaml
+++ b/.github/workflows/auto-simple-suite.yaml
@@ -47,28 +47,23 @@ jobs:
           --data '{"text":"Simple suite pipeline started"}' \
           $SLACK_WEBHOOK_URL
 
-  post-slack-notification-failure:
+  post-slack-notification-results:
     runs-on: ubuntu-latest
     needs: run-simple-suite 
-    if: failure()
+    if: always()
     steps:
       - name: Post to Slack
         env: 
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          if [ "${{ needs.run-simple-suite.result }}" == "success" ]; then
+            MESSAGE="Simple suite results are ready"
+          elif [ "${{ needs.run-simple-suite.result }}" == "failure" ]; then
+            MESSAGE="Simple suite pipeline failed"
+          elif [ "${{ needs.run-simple-suite.result }}" == "cancelled" ]; then
+            MESSAGE="Simple suite pipeline cancelled"
+          fi
+          
           curl -X POST -H 'Content-type: application/json' \
-          --data '{"text":"Simple suite pipeline failed"}' \
-          $SLACK_WEBHOOK_URL
-
-  post-slack-notification-success:
-    runs-on: ubuntu-latest
-    needs: run-simple-suite 
-    if: success()
-    steps:
-      - name: Post to Slack
-        env: 
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' \
-          --data '{"text":"Simple suite results are ready"}' \
+          --data "{\"text\":\"$MESSAGE\"}" \
           $SLACK_WEBHOOK_URL


### PR DESCRIPTION
### Description

This one expands a GHA workflow that posts an automatic notification in the [#smoke-suite-pipeline](https://testautomatio-tvr5558.slack.com/archives/C09FNKH57A8) Slack channel, indicating that the workflow has been completed successfully, failed, or cancelled, in addition to being started.